### PR TITLE
Install django-extensions automatically

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,6 @@ Installing from github:
     pip install -e git://github.com/AxiaCore/django-extlog.git#egg=django-extlog
 
 
-Requirements
-------------
-
-    pip install django-extensions
-
-
 Quick Setup
 -----------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 # Framework
 Django==1.6.5
-
-# Django-specific libraries
-django-extensions==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setup(
     url='https://github.com/AxiaCore/django-extlog',
     author='Vera Mazhuga',
     author_email='ctrl-alt-delete@live.ru',
+    install_requires=[
+        'django-extensions',
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
Adding django-extensions to install_requires in setup.py ensures it's installed
as a dependency when installing django-extlog.
